### PR TITLE
fix: add quickjs-emscripten to devDependencies for CI typecheck

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "esbuild": "^0.27.4",
         "fast-check": "^4.5.3",
         "miniflare": "^4.20260312.0",
+        "quickjs-emscripten": "^0.32.0",
         "tsx": "^4.19.0",
         "typescript": "^6.0.2",
         "typescript-json-schema": "^0.67.1",
@@ -1192,6 +1193,53 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jitl/quickjs-ffi-types": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@jitl/quickjs-ffi-types/-/quickjs-ffi-types-0.32.0.tgz",
+      "integrity": "sha512-v9T+GQpmk43VDJ7d72sf0Nexhk+ArvtUihW27dy7lqAl0zBObFKtSBBIm5RBjwIhE8VwsPPm9PNuvPvNqLWUEg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jitl/quickjs-wasmfile-debug-asyncify": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@jitl/quickjs-wasmfile-debug-asyncify/-/quickjs-wasmfile-debug-asyncify-0.32.0.tgz",
+      "integrity": "sha512-EX8zbXwGqCgAE764M+qvkHtyXDi/FUoMBea0JnES7vCM3P7a2+EOZOjGv85wtZ2sJhI1oJ+nekmqpOODFDY+hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jitl/quickjs-ffi-types": "0.32.0"
+      }
+    },
+    "node_modules/@jitl/quickjs-wasmfile-debug-sync": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@jitl/quickjs-wasmfile-debug-sync/-/quickjs-wasmfile-debug-sync-0.32.0.tgz",
+      "integrity": "sha512-LeYWrPGC1uNCTBWvibo3ZLJj0CSVNYUXvJpXMCmuQ5Sap2cCACc3uvGvYV4homHHBAzfw5akoTqMMS4YFRtw+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jitl/quickjs-ffi-types": "0.32.0"
+      }
+    },
+    "node_modules/@jitl/quickjs-wasmfile-release-asyncify": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@jitl/quickjs-wasmfile-release-asyncify/-/quickjs-wasmfile-release-asyncify-0.32.0.tgz",
+      "integrity": "sha512-3oSwPfja12ICz4aIblB58cuY8JlEq5Txt8Cut4VLo+LH47QN+mzCnSgnbB03hWzg1LBcc+VyyI9UOag7a1NF+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jitl/quickjs-ffi-types": "0.32.0"
+      }
+    },
+    "node_modules/@jitl/quickjs-wasmfile-release-sync": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@jitl/quickjs-wasmfile-release-sync/-/quickjs-wasmfile-release-sync-0.32.0.tgz",
+      "integrity": "sha512-BKNDI/TPBfGlLNGYpLrhcDGXmIk4xHm4MRAisOBnOzpXVn9HZWsfmMAc9WMBrAHjvvds6HOikKeaOBKdPdpVrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jitl/quickjs-ffi-types": "0.32.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -3667,6 +3715,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/quickjs-emscripten": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/quickjs-emscripten/-/quickjs-emscripten-0.32.0.tgz",
+      "integrity": "sha512-So0Sqw869y/S2oE3Nuc0uT3Dhqgvsj8FSrwBdsuTosVsG8ME5/OcudU1GxsrIFdFABgy17GHnTVO9TYV/bLQcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jitl/quickjs-wasmfile-debug-asyncify": "0.32.0",
+        "@jitl/quickjs-wasmfile-debug-sync": "0.32.0",
+        "@jitl/quickjs-wasmfile-release-asyncify": "0.32.0",
+        "@jitl/quickjs-wasmfile-release-sync": "0.32.0",
+        "quickjs-emscripten-core": "0.32.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/quickjs-emscripten-core": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/quickjs-emscripten-core/-/quickjs-emscripten-core-0.32.0.tgz",
+      "integrity": "sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jitl/quickjs-ffi-types": "0.32.0"
       }
     },
     "node_modules/range-parser": {

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "esbuild": "^0.27.4",
     "fast-check": "^4.5.3",
     "miniflare": "^4.20260312.0",
+    "quickjs-emscripten": "^0.32.0",
     "tsx": "^4.19.0",
     "typescript": "^6.0.2",
     "typescript-json-schema": "^0.67.1",
@@ -107,8 +108,8 @@
     "node": ">=20.0.0"
   },
   "peerDependencies": {
-    "tsx": ">=4.0.0",
-    "quickjs-emscripten": ">=0.32.0"
+    "quickjs-emscripten": ">=0.32.0",
+    "tsx": ">=4.0.0"
   },
   "peerDependenciesMeta": {
     "tsx": {


### PR DESCRIPTION
Fixes pre-existing type errors in `src/quickjs/edict-quickjs.ts` by adding `quickjs-emscripten` to `devDependencies`. 

This is required because the QuickJS integration is part of the core source tree and exported as a module, so `tsc` needs the types even if it's an optional peer dependency for users. 

This fix is necessary to make CI pass on `main` and all subsequent PRs (including Dependabot updates).