### PR TITLE
ci: improve robustness and upgrade github-script to v9

### DIFF
--- a/.agent/rules/lessons.md
+++ b/.agent/rules/lessons.md
@@ -200,3 +200,6 @@ Thinking through the /review checklist in your head does NOT satisfy the process
 
 ## 67. Use Proper TypeExpr Kinds, Not Magic Strings
 When adding type-level features, create a new `kind` in `TypeExpr` (e.g., `type_var`) rather than overloading existing kinds with magic strings (e.g., `{ kind: "named", name: "__T" }`). Proper kinds give `kind` switch discrimination, no prefix-checking heuristics, and natural extensibility. This matches how `confidence`, `provenance`, `capability`, and `fresh` are already handled.
+
+## 68. Use GitHub MCP Server, Never `gh` CLI
+Always use MCP server tools (`mcp_github-mcp-server_*`) for GitHub operations. Never fall back to `gh` CLI commands. If the MCP server lacks a tool (e.g., `create_release`), use `push_files`/`create_or_update_file` to commit changes that trigger the desired GitHub Actions workflow.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
           npm run generate-schema
           git diff --exit-code -- schema/edict.schema.json
 
+      - name: Build project
+        run: npm run build
+
       - name: Run tests
         id: tests
         run: npx vitest run --coverage --reporter=default --reporter=json --outputFile=test-results.json
@@ -46,7 +49,7 @@ jobs:
 
       - name: Post structured CI feedback
         if: always()
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Sowiedu/Edict",
     "source": "github"
   },
-  "version": "1.23.0",
+  "version": "1.23.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "edict-lang",
-      "version": "1.23.0",
+      "version": "1.23.1",
       "transport": {
         "type": "stdio"
       }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -123,6 +123,7 @@ export default defineConfig({
                 // Remaining uncovered branches are rare lowering paths (closures, HOFs).
                 "src/ir/lower.ts",
             ],
+            reporters: ["text", "html", "clover", "json", "json-summary"],
             thresholds: {
                 branches: 89,
                 functions: 98,


### PR DESCRIPTION
This PR improves CI robustness by:
1. Adding `npm run build` to the CI workflow. This ensures that the QuickJS and browser bundles are actually built and thus tested (QuickJS tests were being skipped in CI because bundles were missing).
2. Adding the `json-summary` reporter to Vitest. This fixes the CI feedback script's inability to parse coverage data.
3. Upgrading `actions/github-script` to `v9` (addressing the goal of PR #218).
4. Ensuring the environment is ready for the upcoming dependency upgrades.